### PR TITLE
Fix sign in sign up links when logged in

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,15 +1,9 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import {
-  ClerkProvider,
-  SignInButton,
-  SignUpButton,
-  SignedIn,
-  SignedOut,
-  UserButton,
-} from '@clerk/nextjs'
+import { ClerkProvider } from '@clerk/nextjs'
 import { Analytics } from "@vercel/analytics/next"
+import Header from '@/components/Header'
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -38,27 +32,7 @@ export default function RootLayout({
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
           style={{ background: 'var(--background)', color: 'var(--foreground)' }}
         >
-          <header className="fixed top-0 right-0 left-0 flex justify-end items-center px-6 py-4 gap-4 h-20 z-50" style={{ background: 'var(--background)' }}>
-            <SignedOut>
-              <div className="flex items-center gap-3">
-                <SignInButton mode="modal">
-                  <button className="px-4 py-2 font-medium rounded-lg transition-all duration-200" style={{ color: 'var(--foreground)', background: 'transparent', border: '1.5px solid var(--border-gentle)' }}>
-                    Sign In
-                  </button>
-                </SignInButton>
-                <SignUpButton mode="modal">
-                  <button className="px-5 py-2 font-medium rounded-lg transition-all duration-200 text-white" style={{ background: 'var(--accent-green)', border: '1.5px solid var(--accent-green)' }}>
-                    Sign Up
-                  </button>
-                </SignUpButton>
-              </div>
-            </SignedOut>
-            <SignedIn>
-              <div>
-                <UserButton />
-              </div>
-            </SignedIn>
-          </header>
+          <Header />
           {children}
           <Analytics />
         </body>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import {
+  SignInButton,
+  SignUpButton,
+  SignedIn,
+  SignedOut,
+  UserButton,
+} from '@clerk/nextjs'
+
+export default function Header() {
+  return (
+    <header className="fixed top-0 right-0 left-0 flex justify-end items-center px-6 py-4 gap-4 h-20 z-50" style={{ background: 'var(--background)' }}>
+      <SignedOut>
+        <div className="flex items-center gap-3">
+          <SignInButton mode="modal">
+            <button className="px-4 py-2 font-medium rounded-lg transition-all duration-200" style={{ color: 'var(--foreground)', background: 'transparent', border: '1.5px solid var(--border-gentle)' }}>
+              Sign In
+            </button>
+          </SignInButton>
+          <SignUpButton mode="modal">
+            <button className="px-5 py-2 font-medium rounded-lg transition-all duration-200 text-white" style={{ background: 'var(--accent-green)', border: '1.5px solid var(--accent-green)' }}>
+              Sign Up
+            </button>
+          </SignUpButton>
+        </div>
+      </SignedOut>
+      <SignedIn>
+        <div>
+          <UserButton />
+        </div>
+      </SignedIn>
+    </header>
+  )
+}


### PR DESCRIPTION
## Description
The header, containing Clerk's authentication components, was previously rendered within the root server component (`app/layout.tsx`). This led to hydration issues where the UI did not correctly reflect the user's signed-in state, causing "Sign In" and "Sign Up" buttons to remain visible even when a user was logged in.

This PR resolves the issue by extracting the header logic into a new client component (`components/Header.tsx`). This ensures Clerk's `SignedIn` and `SignedOut` components can properly react to authentication state changes on the client side, displaying the correct UI (UserButton vs. Sign In/Sign Up buttons) based on the user's login status.

### Before
When signed in, the header incorrectly displayed "Sign In" and "Sign Up" buttons.

### After
When signed in, the header correctly displays only the `UserButton` (profile icon), hiding "Sign In" and "Sign Up" buttons.

## Testing
### Test Case 1
1. Navigate to the application's homepage.
2. Sign in to the application.
3. Observe the header: Confirm that "Sign In" and "Sign Up" buttons are no longer visible, and the `UserButton` (profile icon) is displayed instead.

### Test Case 2
1. Navigate to the application's homepage.
2. Ensure you are signed out (or sign out if previously signed in).
3. Observe the header: Confirm that "Sign In" and "Sign Up" buttons are correctly displayed.

## Deployment
None.

---
<a href="https://cursor.com/background-agent?bcId=bc-4dd07ea0-d269-4acd-8bba-fe6281081b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4dd07ea0-d269-4acd-8bba-fe6281081b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

