### PR TITLE
Explain resume media demo linking limitation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -210,7 +210,7 @@ export default function Home() {
                   Real Projects
                 </h3>
                 <p className="text-charcoal-600 leading-relaxed">
-                  Display what you&apos;ve actually built. Link to your demo posts, the product launches, and just what you&apos;ve shipped.
+                  Display what you&apos;ve actually built. Link to your demo posts, the product launches, and just what you&apos;ve shipped. In a normal resume, you can&apos;t link to the actual product announcement post where someone could easily see your video demo or media — here you can.
                 </p>
               </div>
 


### PR DESCRIPTION
## Description
Added text to the home page to highlight a key advantage of the platform: the ability to link directly to product announcement posts with video/media demos, which is not possible with traditional resumes.

### Before
The "Real Projects" section on the home page read:
"Display what you've actually built. Link to your demo posts, the product launches, and just what you've shipped."

### After
The "Real Projects" section on the home page now reads:
"Display what you've actually built. Link to your demo posts, the product launches, and just what you've shipped. In a normal resume, you can't link to the actual product announcement post where someone could easily see your video demo or media — here you can."

## Testing
### Test Case 1
1.  Navigate to the home page.
2.  Locate the "Real Projects" section.
3.  Verify the new text about linking to product announcement posts with video/media demos is present.

## Deployment
None.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d14e90d-3e73-4293-9626-5fe4ce172962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2d14e90d-3e73-4293-9626-5fe4ce172962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

