### PR TITLE
Apply grainy paper texture to homepage background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -60,6 +60,68 @@ body {
   font-weight: 400;
   line-height: 1.6;
   letter-spacing: 0.01em;
+  position: relative;
+}
+
+/* Grainy paper texture overlay */
+body::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1;
+  opacity: 0.4;
+  background-image: 
+    repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 2px,
+      rgba(74, 74, 74, 0.03) 2px,
+      rgba(74, 74, 74, 0.03) 4px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      transparent,
+      transparent 2px,
+      rgba(74, 74, 74, 0.03) 2px,
+      rgba(74, 74, 74, 0.03) 4px
+    ),
+    radial-gradient(
+      circle at 20% 80%,
+      rgba(122, 155, 126, 0.05) 0%,
+      transparent 50%
+    ),
+    radial-gradient(
+      circle at 80% 20%,
+      rgba(166, 139, 91, 0.05) 0%,
+      transparent 50%
+    );
+  background-size: 100% 100%, 100% 100%, 200% 200%, 200% 200%;
+  filter: contrast(120%) brightness(98%);
+}
+
+/* Add noise texture */
+body::after {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1;
+  opacity: 0.35;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='3.5' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.3'/%3E%3C/svg%3E");
+  mix-blend-mode: multiply;
+}
+
+/* Ensure content stays above texture */
+body > * {
+  position: relative;
+  z-index: 2;
 }
 
 /* Global styling improvements */


### PR DESCRIPTION
## Description
Adds a subtle, grainy paper texture to the homepage background to enhance its warm, minimalist aesthetic. This was achieved using CSS-only techniques, combining repeating gradients for a cross-hatch pattern, radial gradients for gentle color variations, and an SVG-based fractal noise filter for the grain, all with appropriate blend modes and opacity.

### Before
The homepage background was a plain, solid color.

### After
The homepage background now features a subtle, warm, grainy paper texture.

## Testing
1.  Navigate to the homepage.
2.  Observe the background for the new grainy paper texture.
3.  Verify that all content remains interactive and readable, and the texture does not interfere with user interactions.

### Test Case 1
- **Action:** Load the homepage.
- **Expected:** A subtle, warm, grainy paper texture is visible in the background, without obscuring content.

### Test Case 2
- **Action:** Interact with elements on the homepage (e.g., click buttons, scroll).
- **Expected:** All interactions function normally; the background texture does not block pointer events.

## Deployment
No migrations or environment variables are required.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b19ae27-58c7-43aa-900e-2ebfaedb86bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b19ae27-58c7-43aa-900e-2ebfaedb86bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

