### PR TITLE
feat: add Socials section to footer with text links

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ import ResumeForm from '@/components/ResumeForm'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import SocialLinksForm from '@/components/SocialLinksForm'
 import WalletAddressesForm from '@/components/WalletAddressesForm'
-import { FileText, Users, Shield, Sparkles, Code, Palette, TrendingUp, ExternalLink, Menu, X } from 'lucide-react'
+import { FileText, Users, Shield, Sparkles, Code, Palette, TrendingUp, ExternalLink, Menu, X as CloseIcon } from 'lucide-react'
 import DashboardSidebar from '@/components/DashboardSidebar'
 
 interface UserProfile {
@@ -397,6 +397,28 @@ export default function Home() {
                   build your antiresume
                 </Link>
               </div>
+              
+              <div className="md:col-span-1">
+                <h4 className="font-noto font-medium text-charcoal-800 mb-4">Socials</h4>
+                <div className="space-y-2">
+                  <a 
+                    href="https://x.com/antiresume" 
+                    target="_blank" 
+                    rel="noopener noreferrer"
+                    className="block text-sm text-charcoal-600 hover:text-sage-500 transition-colors"
+                  >
+                    X
+                  </a>
+                  <a 
+                    href="https://instagram.com/antiresume" 
+                    target="_blank" 
+                    rel="noopener noreferrer"
+                    className="block text-sm text-charcoal-600 hover:text-sage-500 transition-colors"
+                  >
+                    Instagram
+                  </a>
+                </div>
+              </div>
             </div>
             
             <div className="border-t border-charcoal-200 mt-8 pt-6 flex flex-col sm:flex-row justify-between items-center">
@@ -419,7 +441,7 @@ export default function Home() {
             className="fixed top-6 left-6 z-50 p-2 rounded-lg bg-matcha-cream border-2 border-sage-300 hover:bg-sage-100 transition-all duration-200"
             aria-label="Toggle menu"
           >
-            {sidebarOpen ? <X className="w-6 h-6 text-charcoal-700" /> : <Menu className="w-6 h-6 text-charcoal-700" />}
+            {sidebarOpen ? <CloseIcon className="w-6 h-6 text-charcoal-700" /> : <Menu className="w-6 h-6 text-charcoal-700" />}
           </button>
         )}
 


### PR DESCRIPTION
## Description
<!-- provide a brief description of the changes in this PR -->

### Before
<!-- add screenshots or videos of the before -->

### After
<!-- add screenshots or videos of the after -->

## Testing
<!-- what did you do to test, what are the steps on how to test --> 

### Test Case 1

### Test Case 2 

## Deployment
<!-- any migrations or env variables --> 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a Socials footer section with links to X and Instagram and alias the close icon for the menu toggle.
> 
> - **Landing page (`app/page.tsx`)**:
>   - **Footer**: Add a new “Socials” column with external links to `https://x.com/antiresume` and `https://instagram.com/antiresume`.
>   - **UI Icon**: Import `X` as `CloseIcon` from `lucide-react` and use it for the hamburger menu close state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6622e50e36804493ed31e531dfdbc911ae837f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->