### PR TITLE
chore: upgrade @clerk/nextjs to v7 and migrate auth-state components

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { SignedIn, SignedOut, SignInButton } from '@clerk/nextjs'
+import { Show, SignInButton } from '@clerk/nextjs'
 import { useState, useEffect } from 'react'
 import UsernameForm from '@/components/UsernameForm'
 import ResumeForm from '@/components/ResumeForm'
@@ -130,7 +130,7 @@ export default function Home() {
 
   return (
     <main className="min-h-screen" style={{ background: 'var(--background)' }}>
-      <SignedOut>
+      <Show when="signed-out">
         {/* Hero Section */}
         <section className="py-20 px-6">
           <div className="max-w-4xl mx-auto text-center">
@@ -431,9 +431,9 @@ export default function Home() {
             </div>
           </div>
         </footer>
-      </SignedOut>
+      </Show>
 
-      <SignedIn>
+      <Show when="signed-in">
         {/* Hamburger Menu Button */}
         {userProfile && (
           <button
@@ -564,7 +564,7 @@ export default function Home() {
           </div>
         )}
         </div>
-      </SignedIn>
+      </Show>
 
       {/* Reset Profile Confirmation Dialog */}
       <ConfirmDialog

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,17 +1,16 @@
 'use client'
 
 import {
+  Show,
   SignInButton,
   SignUpButton,
-  SignedIn,
-  SignedOut,
   UserButton,
 } from '@clerk/nextjs'
 
 export default function Header() {
   return (
     <header className="fixed top-0 right-0 left-0 flex justify-end items-center px-6 py-4 gap-4 h-20 z-50" style={{ background: 'var(--background)' }}>
-      <SignedOut>
+      <Show when="signed-out">
         <div className="flex items-center gap-3">
           <SignInButton mode="modal">
             <button className="px-4 py-2 font-medium rounded-lg transition-all duration-200" style={{ color: 'var(--foreground)', background: 'transparent', border: '1.5px solid var(--border-gentle)' }}>
@@ -24,12 +23,12 @@ export default function Header() {
             </button>
           </SignUpButton>
         </div>
-      </SignedOut>
-      <SignedIn>
+      </Show>
+      <Show when="signed-in">
         <div>
           <UserButton />
         </div>
-      </SignedIn>
+      </Show>
     </header>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
-        "@clerk/nextjs": "^6.31.8",
+        "@clerk/nextjs": "^7.3.7",
         "@supabase/supabase-js": "^2.55.0",
         "@vercel/analytics": "^1.5.0",
         "lucide-react": "^0.553.0",
         "next": "15.5.18",
-        "react": "19.1.0",
-        "react-dom": "19.1.0",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
         "react-tweet": "^3.2.2"
       },
       "devDependencies": {
@@ -43,81 +43,76 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.12.0.tgz",
-      "integrity": "sha512-/MB5Ad9bYsyHT3SE8ay1iUlnK6zHSrkD6EhZH5B6CDkmVeZI9Gm0yG8jOd/L3Hz1UC5AVP59eUaLh/x//yWsVw==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.4.11.tgz",
+      "integrity": "sha512-WT+4FrcMMofxe+irQYUkawoRWaHHXT9/wiRYhRbSb30cOPjN95ViydqPhAyp8ZWAHInHg4mILynQQRJH14SKZQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.24.0",
-        "@clerk/types": "^4.84.0",
-        "cookie": "1.0.2",
+        "@clerk/shared": "^4.12.2",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=18.17.0"
-      }
-    },
-    "node_modules/@clerk/clerk-react": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.46.0.tgz",
-      "integrity": "sha512-Ghd1JA5OPVTbb5rGM+ZfSfZifcWz+KFMwDtN+W/oBKARPpd6jsQNv+SeQFAuqHetfKqz+ylYdAqovKXosiC32Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@clerk/shared": "^3.24.0",
-        "@clerk/types": "^4.84.0",
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=18.17.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+        "node": ">=20.9.0"
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "6.31.8",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.31.8.tgz",
-      "integrity": "sha512-gSGJo8AfucTGmb6ejkVQxRprlhE/dHHHYWau/a4yVkotna9VZFbdX9v1I3KSxdqEQDIFp5jgDY8LHEsKC4yeYQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.3.7.tgz",
+      "integrity": "sha512-CLG63zKPHditk52Z/+c6BJ47V1Q68ACjeps0xHDRW3X/Yv/FZdM+IUKu9Egb5PJ/TkRFxsI1nU5SOY2B8o/WxA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^2.12.0",
-        "@clerk/clerk-react": "^5.46.0",
-        "@clerk/shared": "^3.24.0",
-        "@clerk/types": "^4.84.0",
+        "@clerk/backend": "^3.4.11",
+        "@clerk/react": "^6.6.6",
+        "@clerk/shared": "^4.12.2",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "next": "^13.5.7 || ^14.2.25 || ^15.2.3",
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+        "next": "^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0",
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/react": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.6.6.tgz",
+      "integrity": "sha512-MVHLDZeGobSbGSZgAdb4G1BbB8ZU5XAmBBdIVLXiPOLEst2TYM5bP137WRA76y9GlmVmKYdKzph/TUi87P/JOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.12.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.24.0.tgz",
-      "integrity": "sha512-FVdpS1CFmTy+HjMOl/w6UuIIajaTZZ1TJDbZmGAjS/qitrR+5QVLm5XVrVgwoN/4wCqAiT2g3gukyCf1t/xSCg==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.12.2.tgz",
+      "integrity": "sha512-jDkip8tKTzYz/cPKMCsjOoACH3Xh37zcbCrssMRTYOq3GZypIpZ6WAs4m4G82URL0WY+yz5frrHVjRrHyAb6LA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@clerk/types": "^4.84.0",
+        "@tanstack/query-core": "^5.100.6",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.5",
-        "std-env": "^3.9.0",
-        "swr": "2.3.4"
+        "std-env": "^3.9.0"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": ">=20.9.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -126,18 +121,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@clerk/types": {
-      "version": "4.84.0",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.84.0.tgz",
-      "integrity": "sha512-EyxPPt/DkPQwENWxVMobKmgtEkOz4FgdLO4Q4QMQxAA9w+EooXr3lIqodRtGTW8+/VvrMOWGSrUdFRMA/NBaYg==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "3.1.3"
-      },
-      "engines": {
-        "node": ">=18.17.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1431,6 +1414,16 @@
         "tailwindcss": "4.1.12"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.11.tgz",
+      "integrity": "sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -2593,15 +2586,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2621,6 +2605,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -5343,24 +5328,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-is": {
@@ -5561,9 +5546,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -5813,9 +5798,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
-      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@clerk/nextjs": "^6.31.8",
+    "@clerk/nextjs": "^7.3.7",
     "@supabase/supabase-js": "^2.55.0",
     "@vercel/analytics": "^1.5.0",
     "lucide-react": "^0.553.0",
     "next": "15.5.18",
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
     "react-tweet": "^3.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Bumps `@clerk/nextjs` from `^6.31.8` → `^7.3.7`
- Bumps `react` / `react-dom` from `19.1.0` → `19.2.6` (required by Clerk 7's peer range)
- Migrates `<SignedIn>` / `<SignedOut>` (removed in Clerk 7) to the new `<Show when="signed-in|signed-out">` component in `components/Header.tsx` and `app/page.tsx`

## Why this is its own PR
The original ask was to address Next.js CVEs. PR #57 patches all of them by bumping to 15.5.18 within the 15.x line, which is the lowest-risk fix. We intentionally did **not** bundle the Next.js 16 upgrade with the security fix because:

- 16 isn't strictly necessary — the vulnerabilities are fully resolved on 15.5.18.
- 16 forces a Clerk major bump (6 → 7), which has API breakage (this PR).
- We wanted the security fix to ship fast without dragging in unrelated breaking changes.

So the work is split: PR #57 (CVE fix on 15.x, already merged) → this PR (Clerk migration) → a follow-up PR for Next 16 itself.

## Test plan
- [ ] `npm run build` compiles successfully (verified locally; full build needs `.env.local`)
- [ ] Signed-out state renders Sign In / Sign Up buttons in Header and the marketing hero on `/`
- [ ] Signed-in state renders the UserButton in Header and the dashboard view on `/`
- [ ] `clerkMiddleware()` still gates protected routes
- [ ] `getAuth()` continues to work in `/api/resume`, `/api/username`, `/api/wallets`, `/api/socials`, `/api/profile/[username]`