### PR TITLE
feat: add Instagram embed support to the post stack

### DIFF
--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -15,6 +15,35 @@ export function extractTweetId(url: string): string | null {
 }
 
 /**
+ * Extracts the shortcode + media type from an Instagram URL.
+ * Supports posts (/p/), reels (/reel/ and legacy /reels/), and tv (/tv/).
+ */
+export type InstagramMediaType = 'p' | 'reel' | 'tv'
+
+export interface InstagramPost {
+  shortcode: string
+  mediaType: InstagramMediaType
+}
+
+export function extractInstagramPost(url: string): InstagramPost | null {
+  if (!url) return null
+  const regex = /(?:instagram\.com|instagr\.am)\/(p|reel|reels|tv)\/([A-Za-z0-9_-]+)/i
+  const match = url.match(regex)
+  if (!match) return null
+  const rawType = match[1].toLowerCase()
+  const mediaType: InstagramMediaType = rawType === 'reels' ? 'reel' : (rawType as InstagramMediaType)
+  return { shortcode: match[2], mediaType }
+}
+
+export type PostPlatform = 'twitter' | 'instagram' | 'unknown'
+
+export function detectPostPlatform(url: string): PostPlatform {
+  if (extractTweetId(url)) return 'twitter'
+  if (extractInstagramPost(url)) return 'instagram'
+  return 'unknown'
+}
+
+/**
  * Ensures a URL has an HTTPS protocol prefix
  * @param url - The URL string to normalize
  * @returns The URL with https:// prefix if it didn't have a protocol

--- a/components/InstagramEmbed.tsx
+++ b/components/InstagramEmbed.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useState } from 'react'
+import type { InstagramPost } from '@/app/lib/utils'
+
+interface InstagramEmbedProps {
+  post: InstagramPost
+  title?: string
+}
+
+export default function InstagramEmbed({ post, title }: InstagramEmbedProps) {
+  const [loaded, setLoaded] = useState(false)
+  const src = `https://www.instagram.com/${post.mediaType}/${post.shortcode}/embed`
+
+  return (
+    <div className="instagram-embed" style={{ position: 'relative', width: '100%', minHeight: 480 }}>
+      {!loaded && (
+        <div
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: 'var(--foreground-secondary)',
+            fontSize: 14,
+          }}
+        >
+          Loading Instagram post…
+        </div>
+      )}
+      <iframe
+        src={src}
+        title={title ?? `Instagram ${post.mediaType} ${post.shortcode}`}
+        loading="lazy"
+        allow="encrypted-media"
+        scrolling="no"
+        onLoad={() => setLoaded(true)}
+        style={{
+          width: '100%',
+          minHeight: 480,
+          border: 'none',
+          background: 'transparent',
+          display: 'block',
+        }}
+      />
+    </div>
+  )
+}

--- a/components/PublicTweetCard.tsx
+++ b/components/PublicTweetCard.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { Tweet } from 'react-tweet'
-import { extractTweetId } from '@/app/lib/utils'
+import { detectPostPlatform, extractInstagramPost, extractTweetId } from '@/app/lib/utils'
+import InstagramEmbed from '@/components/InstagramEmbed'
 
 interface TweetItem {
   tweet_link: string
@@ -13,19 +14,26 @@ interface PublicTweetCardProps {
 }
 
 export default function PublicTweetCard({ tweetItem }: PublicTweetCardProps) {
-  const tweetId = extractTweetId(tweetItem.tweet_link)
+  const platform = detectPostPlatform(tweetItem.tweet_link)
 
-  if (!tweetId) {
+  if (platform === 'unknown') {
     return (
       <div
         className="public-tweet-card public-tweet-card--error"
         role="alert"
       >
-        <p className="public-tweet-card__error-title">Invalid tweet URL</p>
+        <p className="public-tweet-card__error-title">Unsupported post URL</p>
         <p className="public-tweet-card__error-body">{tweetItem.tweet_link}</p>
       </div>
     )
   }
+
+  const embed =
+    platform === 'twitter'
+      ? <Tweet id={extractTweetId(tweetItem.tweet_link)!} />
+      : <InstagramEmbed post={extractInstagramPost(tweetItem.tweet_link)!} />
+
+  const sourceLabel = platform === 'twitter' ? 'View on X ↗' : 'View on Instagram ↗'
 
   return (
     <article className="public-tweet-card">
@@ -37,7 +45,7 @@ export default function PublicTweetCard({ tweetItem }: PublicTweetCardProps) {
       )}
 
       <div className="public-tweet-card__embed">
-        <Tweet id={tweetId} />
+        {embed}
       </div>
 
       <footer className="public-tweet-card__footer">
@@ -47,7 +55,7 @@ export default function PublicTweetCard({ tweetItem }: PublicTweetCardProps) {
           target="_blank"
           rel="noopener noreferrer"
         >
-          View on X ↗
+          {sourceLabel}
         </a>
       </footer>
     </article>

--- a/components/ResumeForm.tsx
+++ b/components/ResumeForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { Tweet, Resume } from '@/app/lib/db'
 import TweetCard from '@/components/TweetCard'
+import { detectPostPlatform } from '@/app/lib/utils'
 
 interface ResumeFormProps {
   onResumeUpdated?: () => void
@@ -127,16 +128,20 @@ export default function ResumeForm({ onResumeUpdated }: ResumeFormProps) {
   const validateTweets = () => {
     const validTweets = tweets.filter(tweet => tweet.tweet_link.trim() !== '')
     if (validTweets.length === 0) {
-      setError('At least one tweet link is required')
+      setError('At least one post link is required')
       return false
     }
 
-    // Basic URL validation
     for (const tweet of validTweets) {
       try {
         new URL(tweet.tweet_link)
       } catch {
-        setError('Please enter valid URLs for tweet links')
+        setError('Please enter valid URLs for post links')
+        return false
+      }
+
+      if (detectPostPlatform(tweet.tweet_link) === 'unknown') {
+        setError('Only X/Twitter and Instagram post URLs are supported')
         return false
       }
     }
@@ -246,7 +251,7 @@ export default function ResumeForm({ onResumeUpdated }: ResumeFormProps) {
             {resume ? 'Edit Resume' : 'Create Resume'}
           </h2>
           <p className="text-secondary">
-            Add tweet links to showcase your thoughts and insights
+            Add X/Twitter or Instagram post links to showcase your thoughts and insights
           </p>
         </div>
         {resume && (
@@ -282,7 +287,7 @@ export default function ResumeForm({ onResumeUpdated }: ResumeFormProps) {
                   </div>
                 )}
                 <h3 className="text-xl font-medium heading-handwritten">
-                  Tweet #{index + 1}
+                  Post #{index + 1}
                 </h3>
               </div>
               <div className="flex items-center gap-2">
@@ -329,13 +334,13 @@ export default function ResumeForm({ onResumeUpdated }: ResumeFormProps) {
               <div className="flex-1 min-w-0 space-y-4">
                 <div className="space-y-3">
                   <label className="form-label">
-                    Tweet Link *
+                    Post Link *
                   </label>
                   <input
                     type="url"
                     value={tweet.tweet_link}
                     onChange={(e) => updateTweet(index, 'tweet_link', e.target.value)}
-                    placeholder="https://twitter.com/username/status/…"
+                    placeholder="https://x.com/… or https://instagram.com/p/…"
                     className="input-field"
                     disabled={loading}
                   />
@@ -348,7 +353,7 @@ export default function ResumeForm({ onResumeUpdated }: ResumeFormProps) {
                   <textarea
                     value={tweet.notes || ''}
                     onChange={(e) => updateTweet(index, 'notes', e.target.value)}
-                    placeholder="Add your thoughts about this tweet…"
+                    placeholder="Add your thoughts about this post…"
                     rows={3}
                     className="textarea-field"
                     disabled={loading}
@@ -380,7 +385,7 @@ export default function ResumeForm({ onResumeUpdated }: ResumeFormProps) {
                     background: 'var(--background-card)',
                     color: 'var(--foreground-secondary)'
                   }}>
-                    Add a tweet link to see the preview
+                    Add a post link to see the preview
                   </div>
                 )}
               </div>
@@ -395,7 +400,7 @@ export default function ResumeForm({ onResumeUpdated }: ResumeFormProps) {
             className="btn-base btn-secondary"
             disabled={loading}
           >
-            Add Another Tweet
+            Add Another Post
           </button>
 
           <button

--- a/components/TweetCard.tsx
+++ b/components/TweetCard.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { Tweet } from 'react-tweet'
-import { extractTweetId } from '@/app/lib/utils'
+import { detectPostPlatform, extractInstagramPost, extractTweetId } from '@/app/lib/utils'
+import InstagramEmbed from '@/components/InstagramEmbed'
 
 interface TweetItem {
   tweet_link: string
@@ -15,14 +16,13 @@ interface TweetCardProps {
 }
 
 export default function TweetCard({ tweetItem, variant = 'default' }: TweetCardProps) {
-  const tweetId = extractTweetId(tweetItem.tweet_link)
-  
-  // Handle invalid tweet URL
-  if (!tweetId) {
+  const platform = detectPostPlatform(tweetItem.tweet_link)
+
+  if (platform === 'unknown') {
     if (variant === 'compact') {
       return (
         <div className="alert alert-error text-xs">
-          Invalid tweet URL
+          Unsupported post URL
         </div>
       )
     }
@@ -30,7 +30,7 @@ export default function TweetCard({ tweetItem, variant = 'default' }: TweetCardP
     return (
       <div className="alert alert-error">
         <p className="text-sm font-medium">
-          Invalid tweet URL: {tweetItem.tweet_link}
+          Unsupported post URL: {tweetItem.tweet_link}
         </p>
         {tweetItem.notes && (
           <p className="text-sm mt-3 text-secondary">
@@ -40,14 +40,20 @@ export default function TweetCard({ tweetItem, variant = 'default' }: TweetCardP
       </div>
     )
   }
-  
+
+  const embed =
+    platform === 'twitter'
+      ? <Tweet id={extractTweetId(tweetItem.tweet_link)!} />
+      : <InstagramEmbed post={extractInstagramPost(tweetItem.tweet_link)!} />
+
   if (variant === 'compact') {
-    return <Tweet id={tweetId} />
+    return embed
   }
+
+  const sourceLabel = platform === 'twitter' ? 'View on X ↗' : 'View on Instagram ↗'
 
   return (
     <article className="tweet-card">
-      {/* User's note (if exists) */}
       {tweetItem.notes && (
         <div className="tweet-note" aria-label="Note">
           <span className="tweet-note__label">Note</span>
@@ -55,9 +61,8 @@ export default function TweetCard({ tweetItem, variant = 'default' }: TweetCardP
         </div>
       )}
 
-      {/* Tweet embed */}
       <div className="tweet-embed">
-        <Tweet id={tweetId} />
+        {embed}
       </div>
 
       <div className="tweet-card__footer">
@@ -67,7 +72,7 @@ export default function TweetCard({ tweetItem, variant = 'default' }: TweetCardP
           target="_blank"
           rel="noopener noreferrer"
         >
-          View on X ↗
+          {sourceLabel}
         </a>
       </div>
     </article>


### PR DESCRIPTION
## Summary
Before this PR, the post stack on a profile only embedded X/Twitter posts (via `react-tweet`). Instagram was only stored as a profile social handle (`ig_handle`), with no embed support. This PR adds Instagram posts/reels/IGTV to the same post stack feed.

### What changed
- `app/lib/utils.ts`: new `extractInstagramPost()` and `detectPostPlatform()` helpers alongside the existing `extractTweetId()`. Supports `/p/`, `/reel/`, `/reels/`, and `/tv/` paths on `instagram.com` and `instagr.am`.
- `components/InstagramEmbed.tsx`: new lazy-loaded iframe wrapper around Instagram's official `/embed` endpoint.
- `components/TweetCard.tsx` and `components/PublicTweetCard.tsx`: branch on platform detection to render either `<Tweet>` or `<InstagramEmbed>`. Footer link copy adapts ("View on X" vs "View on Instagram"). Error state copy is now "Unsupported post URL".
- `components/ResumeForm.tsx`: input placeholder, labels, and validation now allow both X/Twitter and Instagram URLs. UI copy renamed Tweet → Post (preview pane, header, "Add Another Post").

### Scope notes
- The DB schema is untouched. The existing `tweet_link` column stores either kind of URL; no migration needed. A rename to `post_link` is a sensible follow-up but intentionally out of scope.
- Instagram embed is via the public `/embed` iframe — no API key, no script tag. Posts must be from public accounts (same constraint as Twitter embeds).
- There's an older `cursor/add-instagram-post-support-and-detection-2362` branch on the remote. This PR is a fresh implementation off `main` per the task brief; you can close that branch.

## Test plan
- [ ] `npm run build` compiles (couldn't fully verify locally — disk was full)
- [ ] Create a profile, add a `https://x.com/...` URL → renders as tweet
- [ ] Add a `https://www.instagram.com/p/<shortcode>/` URL → renders as Instagram iframe with "View on Instagram ↗" footer
- [ ] Add a reel URL → renders the reel via the `/reel/` embed
- [ ] Submit an unsupported URL (e.g. youtube.com) → form rejects with "Only X/Twitter and Instagram post URLs are supported"
- [ ] Public profile page renders mixed feed of tweets + Instagram posts in order