### PR TITLE
ui: don't say "Welcome back" on a user's first sign-up

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,6 +31,7 @@ export default function Home() {
   const [resetLoading, setResetLoading] = useState(false)
   const [resetError, setResetError] = useState('')
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [isNewSignup, setIsNewSignup] = useState(false)
 
   const closeSidebar = () => setSidebarOpen(false)
 
@@ -81,6 +82,10 @@ export default function Home() {
   }, [])
 
   const handleUsernameSet = (username: string) => {
+    // First-time signups (no prior profile) get a welcome message instead of "welcome back"
+    if (!userProfile) {
+      setIsNewSignup(true)
+    }
     // Refresh the profile data
     setUserProfile(prev => prev ? { ...prev, username } : null)
     setShowUpdateForm(false)
@@ -471,10 +476,10 @@ export default function Home() {
               <>
                 <div className="mb-10">
                   <h1 className="text-5xl font-bold mb-3 heading-handwritten">
-                    Welcome back, {userProfile.username}!
+                    {isNewSignup ? `Welcome, ${userProfile.username}!` : `Welcome back, ${userProfile.username}!`}
                   </h1>
                   <p className="text-lg text-secondary">
-                    Edit your profile
+                    {isNewSignup ? 'Your profile is ready — start building it out' : 'Edit your profile'}
                   </p>
                 </div>
 


### PR DESCRIPTION
## Summary
On a brand-new account, immediately after picking a username, the dashboard greeted the user with **"Welcome back, <name>!"** — which is wrong because they were never here before. This PR splits that into two states.

### Behavior
- **First sign-up (just created username this session):** `Welcome, <name>!` / subtitle `Your profile is ready — start building it out`
- **Returning visit (profile already exists on page load):** unchanged — `Welcome back, <name>!` / `Edit your profile`

### Implementation
- New in-session `isNewSignup` boolean (`app/page.tsx`).
- Set to `true` in `handleUsernameSet` only when `userProfile` was `null` at call time, so it triggers on creation but not on later updates.
- Resets on full reload (state-only, not persisted), which is the right behavior: a refresh after first sign-up is conceptually a "return" visit.

## Test plan
- [ ] Sign in as a brand-new user → choose a username → land on dashboard. Heading reads `Welcome, <name>!`.
- [ ] Refresh that page. Heading switches to `Welcome back, <name>!`.
- [ ] Existing account, sign in → heading reads `Welcome back, <name>!` (unchanged from prod).
- [ ] Update username via the update form mid-session → heading stays `Welcome back` if it was already `back`; stays `Welcome` if it was already a new signup. No regression on the update flow.