### PR TITLE
feat: smart-normalize social handles and URLs in profile form

### DIFF
--- a/app/lib/socials.ts
+++ b/app/lib/socials.ts
@@ -44,11 +44,11 @@ export const normalizeInstagramHandle = (raw: string): string => {
 
 /**
  * Accepts any of:
- *   - `jarrensj`                      → https://linkedin.com/in/jarrensj
- *   - `in/jarrensj`                   → https://linkedin.com/in/jarrensj
- *   - `linkedin.com/in/jarrensj`      → https://linkedin.com/in/jarrensj
- *   - `https://linkedin.com/in/foo`   → unchanged
- *   - `linkedin.com/company/acme`     → https://linkedin.com/company/acme (other path segments preserved)
+ *   - `jarrensanjose`                            → https://linkedin.com/in/jarrensanjose
+ *   - `in/jarrensanjose`                         → https://linkedin.com/in/jarrensanjose
+ *   - `linkedin.com/in/jarrensanjose`            → https://linkedin.com/in/jarrensanjose
+ *   - `https://linkedin.com/in/jarrensanjose`    → unchanged
+ *   - `linkedin.com/company/jarrensanjose`       → https://linkedin.com/company/jarrensanjose (other path segments preserved)
  */
 export const normalizeLinkedInUrl = (raw: string): string => {
   const trimmed = raw.trim()

--- a/app/lib/socials.ts
+++ b/app/lib/socials.ts
@@ -6,6 +6,68 @@ export const SOCIAL_FIELD_KEYS: SocialFieldKey[] = ['linkedin', 'twitter_handle'
 
 export type SanitizedSocialFields = Partial<Record<SocialFieldKey, string | null>>
 
+/**
+ * Accepts any of:
+ *   - `jarrensj`
+ *   - `@jarrensj`
+ *   - `https://x.com/jarrensj`
+ *   - `x.com/jarrensj`
+ *   - `twitter.com/jarrensj/status/...` (extracts the username, drops the rest)
+ * and returns just the handle (`jarrensj`). If no recognizable Twitter/X URL
+ * pattern is present, falls back to stripping a leading `@`.
+ */
+export const normalizeTwitterHandle = (raw: string): string => {
+  const trimmed = raw.trim()
+  if (!trimmed) return ''
+  const urlMatch = trimmed.match(/(?:^|\/\/)(?:www\.)?(?:twitter\.com|x\.com)\/([A-Za-z0-9_]+)/i)
+  if (urlMatch) return urlMatch[1]
+  return trimmed.startsWith('@') ? trimmed.slice(1) : trimmed
+}
+
+/**
+ * Accepts any of:
+ *   - `jarrensj`
+ *   - `@jarrensj`
+ *   - `https://instagram.com/jarrensj`
+ *   - `www.instagram.com/jarrensj/`
+ *   - `instagr.am/jarrensj`
+ * and returns just the handle (`jarrensj`). If no recognizable Instagram URL
+ * pattern is present, falls back to stripping a leading `@`.
+ */
+export const normalizeInstagramHandle = (raw: string): string => {
+  const trimmed = raw.trim()
+  if (!trimmed) return ''
+  const urlMatch = trimmed.match(/(?:^|\/\/)(?:www\.)?(?:instagram\.com|instagr\.am)\/([A-Za-z0-9_.]+)/i)
+  if (urlMatch) return urlMatch[1].replace(/\/+$/, '')
+  return trimmed.startsWith('@') ? trimmed.slice(1) : trimmed
+}
+
+/**
+ * Accepts any of:
+ *   - `jarrensj`                      → https://linkedin.com/in/jarrensj
+ *   - `in/jarrensj`                   → https://linkedin.com/in/jarrensj
+ *   - `linkedin.com/in/jarrensj`      → https://linkedin.com/in/jarrensj
+ *   - `https://linkedin.com/in/foo`   → unchanged
+ *   - `linkedin.com/company/acme`     → https://linkedin.com/company/acme (other path segments preserved)
+ */
+export const normalizeLinkedInUrl = (raw: string): string => {
+  const trimmed = raw.trim()
+  if (!trimmed) return ''
+  // Already a full URL or contains linkedin.com → just ensure https
+  if (/^https?:\/\//i.test(trimmed) || /linkedin\.com/i.test(trimmed)) {
+    return ensureHttpsProtocol(trimmed)
+  }
+  // Path-only input like `in/jarrensj`
+  if (trimmed.startsWith('in/') || trimmed.startsWith('/in/')) {
+    return `https://linkedin.com/${trimmed.replace(/^\//, '')}`
+  }
+  // Bare token (no slash, no dot) → assume LinkedIn profile slug
+  if (!trimmed.includes('/') && !trimmed.includes('.')) {
+    return `https://linkedin.com/in/${trimmed.replace(/^@/, '')}`
+  }
+  return ensureHttpsProtocol(trimmed)
+}
+
 export const sanitizeSocialFields = (payload: Record<string, unknown>): SanitizedSocialFields => {
   const result: SanitizedSocialFields = {}
 
@@ -16,12 +78,14 @@ export const sanitizeSocialFields = (payload: Record<string, unknown>): Sanitize
       if (typeof value === 'string') {
         const trimmed = value.trim()
         if (trimmed.length > 0) {
-          // Automatically add https:// protocol to URL fields if missing
-          if (key === 'website' || key === 'linkedin') {
+          if (key === 'website') {
             result[key] = ensureHttpsProtocol(trimmed)
-          } else if (key === 'twitter_handle' || key === 'ig_handle') {
-            // Remove @ symbol from Twitter and Instagram handles if present
-            result[key] = trimmed.startsWith('@') ? trimmed.slice(1) : trimmed
+          } else if (key === 'linkedin') {
+            result[key] = normalizeLinkedInUrl(trimmed)
+          } else if (key === 'twitter_handle') {
+            result[key] = normalizeTwitterHandle(trimmed)
+          } else if (key === 'ig_handle') {
+            result[key] = normalizeInstagramHandle(trimmed)
           }
         } else {
           result[key] = null
@@ -48,4 +112,3 @@ export const emptySocialFields = (): SocialFields => ({
   ig_handle: null,
   website: null,
 })
-

--- a/components/SocialLinksForm.tsx
+++ b/components/SocialLinksForm.tsx
@@ -2,6 +2,11 @@
 
 import { ChangeEvent, FormEvent, useEffect, useState } from 'react'
 import { ensureHttpsProtocol } from '@/app/lib/utils'
+import {
+  normalizeInstagramHandle,
+  normalizeLinkedInUrl,
+  normalizeTwitterHandle,
+} from '@/app/lib/socials'
 
 type SocialFieldKey = 'linkedin' | 'twitter_handle' | 'ig_handle' | 'website'
 
@@ -68,25 +73,22 @@ export default function SocialLinksForm({ onSocialsUpdated }: SocialLinksFormPro
   }
 
   const handleBlur = (field: SocialFieldKey) => (event: ChangeEvent<HTMLInputElement>) => {
-    // Auto-add https:// protocol to URL fields when user leaves the input
-    if (field === 'website' || field === 'linkedin') {
-      const value = event.target.value.trim()
-      if (value) {
-        setSocials((prev) => ({
-          ...prev,
-          [field]: ensureHttpsProtocol(value),
-        }))
-      }
+    const value = event.target.value.trim()
+    if (!value) return
+
+    let normalized = value
+    if (field === 'website') {
+      normalized = ensureHttpsProtocol(value)
+    } else if (field === 'linkedin') {
+      normalized = normalizeLinkedInUrl(value)
+    } else if (field === 'twitter_handle') {
+      normalized = normalizeTwitterHandle(value)
+    } else if (field === 'ig_handle') {
+      normalized = normalizeInstagramHandle(value)
     }
-    // Remove @ symbol from Twitter and Instagram handles if present
-    if (field === 'twitter_handle' || field === 'ig_handle') {
-      const value = event.target.value.trim()
-      if (value) {
-        setSocials((prev) => ({
-          ...prev,
-          [field]: value.startsWith('@') ? value.slice(1) : value,
-        }))
-      }
+
+    if (normalized !== value) {
+      setSocials((prev) => ({ ...prev, [field]: normalized }))
     }
   }
 


### PR DESCRIPTION
## Problem
The four social fields on the profile form only half-normalize input today. If someone pastes a URL into a handle field, the URL is stored verbatim. If someone types just a username into the LinkedIn field, it's prefixed with \`https://\` and ends up broken.

## What this PR does
For every social field, accept either form (handle or URL) and store the canonical one.

### Twitter and Instagram handle fields
Store **just the username**. Accepted inputs (all become \`jarrensj\`):
- \`jarrensj\`
- \`@jarrensj\`
- \`x.com/jarrensj\` / \`twitter.com/jarrensj\` / \`https://x.com/jarrensj\`
- \`instagram.com/jarrensj\` / \`instagr.am/jarrensj\` / \`https://www.instagram.com/jarrensj/\`
- A full status/post URL with extra path segments: only the username portion is kept

### LinkedIn field
Store the **full LinkedIn URL**. Accepted inputs (all become \`https://linkedin.com/in/jarrensj\`):
- \`jarrensj\`           (bare token → assumed LinkedIn slug)
- \`in/jarrensanjose\`        (path-only)
- \`linkedin.com/in/jarrensanjose\` (gets \`https://\` prefix)
- \`https://linkedin.com/in/jarrensanjose\` (unchanged)

Non-\`/in/\` LinkedIn URLs are preserved with \`https://\` prefixed (e.g. \`linkedin.com/company/acme\` stays as that path).

### Website field
Unchanged — just ensures \`https://\` prefix. Too many shapes of valid sites to guess further.

## Where it runs
Normalization is centralized in \`app/lib/socials.ts\` so the same logic runs:
- Client-side, on \`onBlur\` in \`SocialLinksForm\` — the user sees the normalized value the moment they tab out of the field
- Server-side, in \`sanitizeSocialFields\` on \`PUT /api/socials\` — defense in depth, also catches anything submitted via direct API call

## Is this actually better UX?
**Yes for handle fields** (Twitter / Instagram). People copy-paste URLs constantly. The current behavior of storing a literal URL in a handle field is a clear bug.

**Mostly yes for LinkedIn** with one judgment call worth flagging: bare \`jarrensj\` is interpreted as a LinkedIn profile slug. If the user typed \`jarrensj\` expecting nothing to happen, they'll see it expand into a full URL on blur. That's slightly surprising but matches the placeholder hint (\`https://linkedin.com/in/yourprofile\`) and is the most useful guess we can make. Worst case if it's wrong: the URL points to a non-existent profile, which the user can edit before saving. Open to changing this if you'd prefer LinkedIn to be strict (only accept full URLs).

**Unchanged for Website**, intentionally.

## Test plan
- [ ] Paste \`https://x.com/jarrensj\` into Twitter handle → on blur becomes \`jarrensj\`
- [ ] Type \`@jarrensj\` into Instagram handle → on blur becomes \`jarrensj\`
- [ ] Paste \`https://twitter.com/jarrensj/status/1234567890\` into Twitter handle → becomes \`jarrensj\`
- [ ] Type \`jarrensanjose\` into LinkedIn → on blur becomes \`https://linkedin.com/in/jarrensanj\ose`
- [ ] Type \`in/jarrensanjose\` into LinkedIn → becomes \`https://linkedin.com/in/jarrensanjose\`
- [ ] Paste \`https://linkedin.com/company/acme\` into LinkedIn → stays as-is (just gets \`https://\` if missing)
- [ ] Existing values on a saved profile re-load and re-save without drift