### PR TITLE
feat: free-form crop on staged photo before upload

### DIFF
--- a/components/PhotoCropper.tsx
+++ b/components/PhotoCropper.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import ReactCrop, { centerCrop, makeAspectCrop, type Crop, type PixelCrop } from 'react-image-crop'
+import 'react-image-crop/dist/ReactCrop.css'
+
+interface PhotoCropperProps {
+  /** Source file the user picked / dropped / pasted */
+  file: File
+  /** Called when the user clicks Apply Crop — receives the cropped File. */
+  onApply: (cropped: File) => void
+  /** Called when the user clicks Cancel — original file is kept. */
+  onCancel: () => void
+}
+
+/**
+ * Free-form image cropper. Aspect is unlocked by default; users can drag the
+ * crop region to move it and drag any corner/edge to resize each axis
+ * independently. On apply, the visible crop region is rendered to a canvas at
+ * the source image's native resolution and returned as a JPEG/PNG File matching
+ * the source mime type. Original file extension and basename are preserved.
+ */
+export default function PhotoCropper({ file, onApply, onCancel }: PhotoCropperProps) {
+  const [imageSrc, setImageSrc] = useState<string | null>(null)
+  const [crop, setCrop] = useState<Crop>()
+  const [completedCrop, setCompletedCrop] = useState<PixelCrop>()
+  const [working, setWorking] = useState(false)
+  const imgRef = useRef<HTMLImageElement | null>(null)
+
+  // Decode the source file to a data URL the <img> can render.
+  if (imageSrc === null) {
+    const reader = new FileReader()
+    reader.onload = () => setImageSrc(reader.result as string)
+    reader.readAsDataURL(file)
+  }
+
+  const handleImageLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    const { width, height } = e.currentTarget
+    // Start with a centered free-form crop covering 80% of the smaller side.
+    const initial = centerCrop(
+      makeAspectCrop({ unit: '%', width: 80 }, width / height, width, height),
+      width,
+      height,
+    )
+    setCrop(initial)
+  }
+
+  const buildCroppedFile = async (): Promise<File | null> => {
+    if (!completedCrop || !imgRef.current) return null
+    const img = imgRef.current
+
+    const scaleX = img.naturalWidth / img.width
+    const scaleY = img.naturalHeight / img.height
+    const sx = completedCrop.x * scaleX
+    const sy = completedCrop.y * scaleY
+    const sw = completedCrop.width * scaleX
+    const sh = completedCrop.height * scaleY
+
+    if (sw < 1 || sh < 1) return null
+
+    const canvas = document.createElement('canvas')
+    canvas.width = Math.round(sw)
+    canvas.height = Math.round(sh)
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return null
+    ctx.imageSmoothingQuality = 'high'
+    ctx.drawImage(img, sx, sy, sw, sh, 0, 0, canvas.width, canvas.height)
+
+    // Match the source MIME so the upload validation on the server still passes.
+    const outType = ['image/png', 'image/webp', 'image/gif'].includes(file.type)
+      ? file.type
+      : 'image/jpeg'
+    const blob: Blob | null = await new Promise((resolve) =>
+      canvas.toBlob((b) => resolve(b), outType, 0.92),
+    )
+    if (!blob) return null
+
+    // Preserve the original basename, just suffix it so the user can tell.
+    const dot = file.name.lastIndexOf('.')
+    const base = dot > 0 ? file.name.slice(0, dot) : file.name
+    const ext = outType === 'image/png'
+      ? 'png'
+      : outType === 'image/webp'
+        ? 'webp'
+        : outType === 'image/gif'
+          ? 'gif'
+          : 'jpg'
+    return new File([blob], `${base}-cropped.${ext}`, { type: outType })
+  }
+
+  const handleApply = async () => {
+    setWorking(true)
+    try {
+      const cropped = await buildCroppedFile()
+      if (cropped) onApply(cropped)
+    } finally {
+      setWorking(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {imageSrc && (
+        <div className="flex justify-center">
+          <ReactCrop
+            crop={crop}
+            onChange={(c) => setCrop(c)}
+            onComplete={(c) => setCompletedCrop(c)}
+            keepSelection
+            // Free-form: no aspect prop, no `locked`, no min/max — user can
+            // drag each handle independently.
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              ref={imgRef}
+              src={imageSrc}
+              alt="Crop preview"
+              onLoad={handleImageLoad}
+              style={{ maxHeight: '60vh', maxWidth: '100%' }}
+            />
+          </ReactCrop>
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center justify-end gap-3">
+        <p className="text-xs text-secondary mr-auto">
+          Drag the box to move. Drag any corner or edge to resize freely — any aspect ratio.
+        </p>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={working}
+          className="btn-base btn-outline"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={handleApply}
+          disabled={working || !completedCrop || completedCrop.width < 1 || completedCrop.height < 1}
+          className="btn-base btn-primary"
+        >
+          {working ? 'Applying…' : 'Apply Crop'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/PhotoGalleryForm.tsx
+++ b/components/PhotoGalleryForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ChangeEvent, ClipboardEvent, DragEvent, useEffect, useRef, useState } from 'react'
+import PhotoCropper from '@/components/PhotoCropper'
 
 interface PhotoItem {
   id: string
@@ -27,6 +28,7 @@ export default function PhotoGalleryForm() {
   const [pendingFile, setPendingFile] = useState<File | null>(null)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [isDragging, setIsDragging] = useState(false)
+  const [isCropping, setIsCropping] = useState(false)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const dragCounter = useRef(0)
 
@@ -74,6 +76,7 @@ export default function PhotoGalleryForm() {
     setError('')
     setSuccess('')
     setPendingFile(file)
+    setIsCropping(false)
   }
 
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -82,7 +85,13 @@ export default function PhotoGalleryForm() {
 
   const clearPending = () => {
     setPendingFile(null)
+    setIsCropping(false)
     if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  const handleCropApply = (cropped: File) => {
+    setPendingFile(cropped)
+    setIsCropping(false)
   }
 
   const handleUpload = async () => {
@@ -232,6 +241,17 @@ export default function PhotoGalleryForm() {
                 type="button"
                 onClick={(e) => {
                   e.stopPropagation()
+                  setIsCropping(true)
+                }}
+                className="btn-base btn-outline text-sm"
+                disabled={uploading}
+              >
+                Crop
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
                   clearPending()
                 }}
                 className="btn-base btn-outline text-sm"
@@ -260,6 +280,19 @@ export default function PhotoGalleryForm() {
             className="sr-only"
           />
         </div>
+
+        {isCropping && pendingFile && (
+          <div
+            className="rounded-2xl border p-4"
+            style={{ borderColor: 'var(--border-gentle)', background: 'var(--background-card)' }}
+          >
+            <PhotoCropper
+              file={pendingFile}
+              onApply={handleCropApply}
+              onCancel={() => setIsCropping(false)}
+            />
+          </div>
+        )}
 
         <div>
           <label className="form-label" htmlFor="photo-caption">Caption (optional)</label>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "next": "15.5.18",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-image-crop": "^11.0.10",
         "react-tweet": "^3.2.2"
       },
       "devDependencies": {
@@ -6049,6 +6050,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-image-crop": {
+      "version": "11.0.10",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-11.0.10.tgz",
+      "integrity": "sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "next": "15.5.18",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-image-crop": "^11.0.10",
     "react-tweet": "^3.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Chained on top of #68. After a file is selected/dropped/pasted into the photo gallery, the user can now **crop it any way** before it gets uploaded — any aspect ratio, free-form rectangle. Same spirit as your `resize-1024` repo but with no aspect lock, so the user can carve out any region (portrait, landscape, square, weird ratio) instead of just a fixed square.

## Behavior
- The preview row gains a new **Crop** button alongside Replace.
- Clicking Crop expands an inline cropper panel under the dropzone with the image displayed.
- Drag the crop box to move it; drag any **corner or edge handle** to resize each axis independently — no locked aspect ratio.
- **Apply Crop** replaces the staged file with the cropped version (the preview row updates immediately), and the regular Upload flow uploads the cropped file.
- **Cancel** closes the cropper and keeps the original staged file untouched.
- After Apply you can crop *again* — Crop button now operates on the previously cropped file, so users can iteratively tighten.

## Implementation
- New `react-image-crop` dependency (MIT, ~25 KB gz). I deliberately did not pass an `aspect` prop — that's what makes it free-form.
- New `components/PhotoCropper.tsx` — handles the rendering, the crop state, and the canvas export. Output is rendered at the **source image's native resolution** (not the display size), so quality matches the original.
- Cropped file is encoded back to the source MIME (or falls back to JPEG for unsupported types) and wrapped in a `File` with a `-cropped` basename suffix. The existing upload pipeline (`POST /api/photos`) consumes it with no API changes.
- Initial crop region: centered, ~80% of the image's smaller side. The user can immediately reshape it.

## What this does NOT change
- The S3 upload path, validation (5 MB, jpeg/png/webp/gif), API contract, public profile rendering — all unchanged.
- Captions still work as before, set after cropping.

## Test plan
- [ ] Drop or paste a wide image → click **Crop** → drag right edge inward to make it square → Apply → preview thumb is now square → upload → public profile renders the square version
- [ ] Drop a tall portrait → Crop → drag bottom edge to trim the bottom → Apply → uploaded image is the trimmed version at native resolution
- [ ] Open Crop → reshape → click **Cancel** → preview row still shows original file, no upload happens
- [ ] Crop once, Apply, then Crop again → second crop operates on the first crop's output (i.e., iterative crop works)
- [ ] Crop a transparent PNG → output is still PNG (MIME preserved)
- [ ] Crop a GIF → output is GIF (animation may be lost — canvas can't re-encode multi-frame; flagging in case you want to disable cropping for GIFs as a follow-up)

## Base
Stacked on **#68** (`feat/photo-gallery-paste-drop`), which itself is stacked on **#67** (`feat/profile-photo-gallery`). Once #67 merges, both child branches need a rebase onto main.