### PR TITLE
feat: project-offline landing notice + coming-soon dialog

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ClerkProvider } from '@clerk/nextjs'
 import { Analytics } from "@vercel/analytics/next"
+import Header from "@/components/Header"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -31,6 +32,7 @@ export default function RootLayout({
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
           style={{ background: 'var(--background)', color: 'var(--foreground)' }}
         >
+          <Header />
           {children}
           <Analytics />
         </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,6 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ClerkProvider } from '@clerk/nextjs'
 import { Analytics } from "@vercel/analytics/next"
-import Header from "@/components/Header"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -32,7 +31,6 @@ export default function RootLayout({
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
           style={{ background: 'var(--background)', color: 'var(--foreground)' }}
         >
-          <Header />
           {children}
           <Analytics />
         </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,8 +8,10 @@ import ResumeForm from '@/components/ResumeForm'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import SocialLinksForm from '@/components/SocialLinksForm'
 import WalletAddressesForm from '@/components/WalletAddressesForm'
-import { FileText, Users, Shield, Sparkles, Code, Palette, TrendingUp, ExternalLink, Menu, X as CloseIcon } from 'lucide-react'
+import { FileText, Users, Shield, Sparkles, Code, Palette, TrendingUp, ExternalLink, Menu, X as CloseIcon, AlertTriangle } from 'lucide-react'
 import DashboardSidebar from '@/components/DashboardSidebar'
+
+const PROJECT_OFFLINE = true
 
 interface UserProfile {
   id: string
@@ -31,6 +33,12 @@ export default function Home() {
   const [resetLoading, setResetLoading] = useState(false)
   const [resetError, setResetError] = useState('')
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [showOfflineDialog, setShowOfflineDialog] = useState(false)
+
+  const openOfflineDialog = (event?: React.MouseEvent) => {
+    event?.preventDefault()
+    setShowOfflineDialog(true)
+  }
 
   const closeSidebar = () => setSidebarOpen(false)
 
@@ -130,6 +138,36 @@ export default function Home() {
 
   return (
     <main className="min-h-screen" style={{ background: 'var(--background)' }}>
+      {PROJECT_OFFLINE && (
+        <div className="border-b-2 border-amber-300 bg-amber-100/80 px-6 py-3">
+          <div className="max-w-4xl mx-auto flex items-start gap-3 text-sm text-charcoal-800">
+            <AlertTriangle className="w-5 h-5 shrink-0 text-amber-600" strokeWidth={1.75} aria-hidden="true" />
+            <p className="leading-relaxed">
+              <span className="font-medium">antiresume is temporarily offline.</span>{' '}
+              The database is down and the project is paused while we work on it. Follow{' '}
+              <a
+                href="https://x.com/antiresume"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline underline-offset-2 hover:text-sage-500"
+              >
+                @antiresume on X
+              </a>{' '}
+              or{' '}
+              <a
+                href="https://instagram.com/antiresume"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline underline-offset-2 hover:text-sage-500"
+              >
+                Instagram
+              </a>{' '}
+              for alerts when it&apos;s live again.
+            </p>
+          </div>
+        </div>
+      )}
+
       <Show when="signed-out">
         {/* Hero Section */}
         <section className="py-20 px-6">
@@ -153,11 +191,21 @@ export default function Home() {
 
             {/* CTA Button */}
             <div className="mb-16">
-              <SignInButton>
-                <button className="bg-charcoal-700 hover:bg-charcoal-800 text-matcha-cream font-zen text-lg px-8 py-4 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300">
+              {PROJECT_OFFLINE ? (
+                <button
+                  type="button"
+                  onClick={openOfflineDialog}
+                  className="bg-charcoal-700 hover:bg-charcoal-800 text-matcha-cream font-zen text-lg px-8 py-4 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300"
+                >
                   Show your antiresume
                 </button>
-              </SignInButton>
+              ) : (
+                <SignInButton>
+                  <button className="bg-charcoal-700 hover:bg-charcoal-800 text-matcha-cream font-zen text-lg px-8 py-4 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300">
+                    Show your antiresume
+                  </button>
+                </SignInButton>
+              )}
             </div>
 
             {/* Subtle decorative line */}
@@ -360,6 +408,7 @@ export default function Home() {
                 href="/jarrensj"
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={PROJECT_OFFLINE ? openOfflineDialog : undefined}
                 className="bg-matcha-cream hover:bg-sage-100 text-charcoal-800 font-zen px-6 py-3 rounded-xl border-2 border-sage-300 hover:border-sage-400 transition-all duration-300 shadow-sm hover:shadow-md"
               >
                 /jarrensj
@@ -368,6 +417,7 @@ export default function Home() {
                 href="/jarrensj"
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={PROJECT_OFFLINE ? openOfflineDialog : undefined}
                 className="bg-matcha-cream hover:bg-sage-100 text-charcoal-800 font-zen px-6 py-3 rounded-xl border-2 border-sage-300 hover:border-sage-400 transition-all duration-300 shadow-sm hover:shadow-md"
               >
                 /jarrensj
@@ -376,6 +426,7 @@ export default function Home() {
                 href="/jarrensj"
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={PROJECT_OFFLINE ? openOfflineDialog : undefined}
                 className="bg-matcha-cream hover:bg-sage-100 text-charcoal-800 font-zen px-6 py-3 rounded-xl border-2 border-sage-300 hover:border-sage-400 transition-all duration-300 shadow-sm hover:shadow-md"
               >
                 /jarrensj
@@ -565,6 +616,66 @@ export default function Home() {
         )}
         </div>
       </Show>
+
+      {/* Project Offline Dialog */}
+      {showOfflineDialog && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center px-4 bg-charcoal-900/40"
+          onClick={() => setShowOfflineDialog(false)}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="offline-dialog-title"
+        >
+          <div
+            className="relative w-full max-w-md bg-matcha-cream rounded-2xl shadow-xl border-2 border-sage-300 p-6"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <button
+              type="button"
+              onClick={() => setShowOfflineDialog(false)}
+              className="absolute top-3 right-3 p-1 rounded-md text-charcoal-500 hover:text-charcoal-800 hover:bg-sage-100 transition-colors"
+              aria-label="Close"
+            >
+              <CloseIcon className="w-5 h-5" />
+            </button>
+
+            <div className="flex items-start gap-4 mb-4">
+              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-amber-500/10 text-amber-600">
+                <AlertTriangle className="h-6 w-6" aria-hidden="true" />
+              </div>
+              <div className="flex-1 min-w-0 pr-6">
+                <h2 id="offline-dialog-title" className="text-xl font-noto font-medium text-charcoal-800 mb-2">
+                  antiresume is coming back soon
+                </h2>
+                <p className="text-sm text-charcoal-600 leading-relaxed">
+                  The project is temporarily offline while the database is down. Follow antiresume on X or Instagram for an alert when it&apos;s live again.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-3 mt-2">
+              <a
+                href="https://x.com/antiresume"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex-1 inline-flex items-center justify-center gap-2 bg-charcoal-700 hover:bg-charcoal-800 text-matcha-cream font-zen px-4 py-2.5 rounded-xl transition-all duration-200"
+              >
+                <ExternalLink className="w-4 h-4" />
+                Follow on X
+              </a>
+              <a
+                href="https://instagram.com/antiresume"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex-1 inline-flex items-center justify-center gap-2 bg-matcha-cream hover:bg-sage-100 text-charcoal-800 font-zen px-4 py-2.5 rounded-xl border-2 border-sage-300 hover:border-sage-400 transition-all duration-200"
+              >
+                <ExternalLink className="w-4 h-4" />
+                Follow on Instagram
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Reset Profile Confirmation Dialog */}
       <ConfirmDialog

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ import ResumeForm from '@/components/ResumeForm'
 import ConfirmDialog from '@/components/ConfirmDialog'
 import SocialLinksForm from '@/components/SocialLinksForm'
 import WalletAddressesForm from '@/components/WalletAddressesForm'
-import { FileText, Users, Shield, Sparkles, Code, Palette, TrendingUp, ExternalLink, Menu, X as CloseIcon, AlertTriangle } from 'lucide-react'
+import { FileText, Users, Shield, Sparkles, Code, Palette, TrendingUp, ExternalLink, Menu, X as CloseIcon } from 'lucide-react'
 import DashboardSidebar from '@/components/DashboardSidebar'
 import OfflineDialog, { PROJECT_OFFLINE } from '@/components/OfflineDialog'
 
@@ -137,36 +137,6 @@ export default function Home() {
 
   return (
     <main className="min-h-screen" style={{ background: 'var(--background)' }}>
-      {PROJECT_OFFLINE && (
-        <div className="border-b-2 border-amber-300 bg-amber-100/80 px-6 py-3">
-          <div className="max-w-4xl mx-auto flex items-start gap-3 text-sm text-charcoal-800">
-            <AlertTriangle className="w-5 h-5 shrink-0 text-amber-600" strokeWidth={1.75} aria-hidden="true" />
-            <p className="leading-relaxed">
-              <span className="font-medium">antiresume is temporarily offline.</span>{' '}
-              The database is down and the project is paused while we work on it. Follow{' '}
-              <a
-                href="https://x.com/antiresume"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline underline-offset-2 hover:text-sage-500"
-              >
-                @antiresume on X
-              </a>{' '}
-              or{' '}
-              <a
-                href="https://instagram.com/antiresume"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline underline-offset-2 hover:text-sage-500"
-              >
-                Instagram
-              </a>{' '}
-              for alerts when it&apos;s live again.
-            </p>
-          </div>
-        </div>
-      )}
-
       <Show when="signed-out">
         {/* Hero Section */}
         <section className="py-20 px-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,8 +10,7 @@ import SocialLinksForm from '@/components/SocialLinksForm'
 import WalletAddressesForm from '@/components/WalletAddressesForm'
 import { FileText, Users, Shield, Sparkles, Code, Palette, TrendingUp, ExternalLink, Menu, X as CloseIcon, AlertTriangle } from 'lucide-react'
 import DashboardSidebar from '@/components/DashboardSidebar'
-
-const PROJECT_OFFLINE = true
+import OfflineDialog, { PROJECT_OFFLINE } from '@/components/OfflineDialog'
 
 interface UserProfile {
   id: string
@@ -617,65 +616,7 @@ export default function Home() {
         </div>
       </Show>
 
-      {/* Project Offline Dialog */}
-      {showOfflineDialog && (
-        <div
-          className="fixed inset-0 z-[60] flex items-center justify-center px-4 bg-charcoal-900/40"
-          onClick={() => setShowOfflineDialog(false)}
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="offline-dialog-title"
-        >
-          <div
-            className="relative w-full max-w-md bg-matcha-cream rounded-2xl shadow-xl border-2 border-sage-300 p-6"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <button
-              type="button"
-              onClick={() => setShowOfflineDialog(false)}
-              className="absolute top-3 right-3 p-1 rounded-md text-charcoal-500 hover:text-charcoal-800 hover:bg-sage-100 transition-colors"
-              aria-label="Close"
-            >
-              <CloseIcon className="w-5 h-5" />
-            </button>
-
-            <div className="flex items-start gap-4 mb-4">
-              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-amber-500/10 text-amber-600">
-                <AlertTriangle className="h-6 w-6" aria-hidden="true" />
-              </div>
-              <div className="flex-1 min-w-0 pr-6">
-                <h2 id="offline-dialog-title" className="text-xl font-noto font-medium text-charcoal-800 mb-2">
-                  antiresume is coming back soon
-                </h2>
-                <p className="text-sm text-charcoal-600 leading-relaxed">
-                  The project is temporarily offline while the database is down. Follow antiresume on X or Instagram for an alert when it&apos;s live again.
-                </p>
-              </div>
-            </div>
-
-            <div className="flex flex-col sm:flex-row gap-3 mt-2">
-              <a
-                href="https://x.com/antiresume"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex-1 inline-flex items-center justify-center gap-2 bg-charcoal-700 hover:bg-charcoal-800 text-matcha-cream font-zen px-4 py-2.5 rounded-xl transition-all duration-200"
-              >
-                <ExternalLink className="w-4 h-4" />
-                Follow on X
-              </a>
-              <a
-                href="https://instagram.com/antiresume"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex-1 inline-flex items-center justify-center gap-2 bg-matcha-cream hover:bg-sage-100 text-charcoal-800 font-zen px-4 py-2.5 rounded-xl border-2 border-sage-300 hover:border-sage-400 transition-all duration-200"
-              >
-                <ExternalLink className="w-4 h-4" />
-                Follow on Instagram
-              </a>
-            </div>
-          </div>
-        </div>
-      )}
+      <OfflineDialog open={showOfflineDialog} onClose={() => setShowOfflineDialog(false)} />
 
       {/* Reset Profile Confirmation Dialog */}
       <ConfirmDialog

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,27 +1,59 @@
 'use client'
 
+import { useState } from 'react'
 import {
   Show,
   SignInButton,
   SignUpButton,
   UserButton,
 } from '@clerk/nextjs'
+import OfflineDialog, { PROJECT_OFFLINE } from '@/components/OfflineDialog'
 
 export default function Header() {
+  const [showOfflineDialog, setShowOfflineDialog] = useState(false)
+  const openOfflineDialog = () => setShowOfflineDialog(true)
+
+  const signInButton = (
+    <button className="px-4 py-2 font-medium rounded-lg transition-all duration-200" style={{ color: 'var(--foreground)', background: 'transparent', border: '1.5px solid var(--border-gentle)' }}>
+      Sign In
+    </button>
+  )
+
+  const signUpButton = (
+    <button className="px-5 py-2 font-medium rounded-lg transition-all duration-200 text-white" style={{ background: 'var(--accent-green)', border: '1.5px solid var(--accent-green)' }}>
+      Sign Up
+    </button>
+  )
+
   return (
     <header className="fixed top-0 right-0 left-0 flex justify-end items-center px-6 py-4 gap-4 h-20 z-50" style={{ background: 'var(--background)' }}>
       <Show when="signed-out">
         <div className="flex items-center gap-3">
-          <SignInButton mode="modal">
-            <button className="px-4 py-2 font-medium rounded-lg transition-all duration-200" style={{ color: 'var(--foreground)', background: 'transparent', border: '1.5px solid var(--border-gentle)' }}>
-              Sign In
-            </button>
-          </SignInButton>
-          <SignUpButton mode="modal">
-            <button className="px-5 py-2 font-medium rounded-lg transition-all duration-200 text-white" style={{ background: 'var(--accent-green)', border: '1.5px solid var(--accent-green)' }}>
-              Sign Up
-            </button>
-          </SignUpButton>
+          {PROJECT_OFFLINE ? (
+            <>
+              <button
+                type="button"
+                onClick={openOfflineDialog}
+                className="px-4 py-2 font-medium rounded-lg transition-all duration-200"
+                style={{ color: 'var(--foreground)', background: 'transparent', border: '1.5px solid var(--border-gentle)' }}
+              >
+                Sign In
+              </button>
+              <button
+                type="button"
+                onClick={openOfflineDialog}
+                className="px-5 py-2 font-medium rounded-lg transition-all duration-200 text-white"
+                style={{ background: 'var(--accent-green)', border: '1.5px solid var(--accent-green)' }}
+              >
+                Sign Up
+              </button>
+            </>
+          ) : (
+            <>
+              <SignInButton mode="modal">{signInButton}</SignInButton>
+              <SignUpButton mode="modal">{signUpButton}</SignUpButton>
+            </>
+          )}
         </div>
       </Show>
       <Show when="signed-in">
@@ -29,7 +61,8 @@ export default function Header() {
           <UserButton />
         </div>
       </Show>
+
+      <OfflineDialog open={showOfflineDialog} onClose={() => setShowOfflineDialog(false)} />
     </header>
   )
 }
-

--- a/components/OfflineDialog.tsx
+++ b/components/OfflineDialog.tsx
@@ -52,10 +52,10 @@ export default function OfflineDialog({ open, onClose }: OfflineDialogProps) {
         </button>
 
         <h2 id="offline-dialog-title" className="text-base font-noto font-medium text-charcoal-800 mb-1">
-          coming back soon
+          project is offline
         </h2>
         <p className="text-xs text-charcoal-600 leading-relaxed mb-4">
-          follow for an alert when antiresume is live again
+          follow our socials to know when we&apos;re back
         </p>
 
         <div className="flex items-center justify-center gap-5">

--- a/components/OfflineDialog.tsx
+++ b/components/OfflineDialog.tsx
@@ -58,24 +58,24 @@ export default function OfflineDialog({ open, onClose }: OfflineDialogProps) {
           follow for an alert when antiresume is live again
         </p>
 
-        <div className="flex items-center justify-center gap-3">
+        <div className="flex items-center justify-center gap-5">
           <a
             href="https://x.com/antiresume"
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Follow antiresume on X"
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-charcoal-700 hover:bg-charcoal-800 text-matcha-cream transition-all duration-200"
+            className="text-charcoal-700 hover:text-sage-500 transition-colors duration-200"
           >
-            <XLogo className="h-4 w-4" />
+            <XLogo className="h-6 w-6" />
           </a>
           <a
             href="https://instagram.com/antiresume"
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Follow antiresume on Instagram"
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-matcha-cream hover:bg-sage-100 text-charcoal-800 border-2 border-sage-300 hover:border-sage-400 transition-all duration-200"
+            className="text-charcoal-700 hover:text-sage-500 transition-colors duration-200"
           >
-            <InstagramLogo className="h-4 w-4" />
+            <InstagramLogo className="h-6 w-6" />
           </a>
         </div>
       </div>

--- a/components/OfflineDialog.tsx
+++ b/components/OfflineDialog.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { AlertTriangle, ExternalLink, X as CloseIcon } from 'lucide-react'
+
+export const PROJECT_OFFLINE = true
+
+interface OfflineDialogProps {
+  open: boolean
+  onClose: () => void
+}
+
+export default function OfflineDialog({ open, onClose }: OfflineDialogProps) {
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center px-4 bg-charcoal-900/40"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="offline-dialog-title"
+    >
+      <div
+        className="relative w-full max-w-md bg-matcha-cream rounded-2xl shadow-xl border-2 border-sage-300 p-6"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute top-3 right-3 p-1 rounded-md text-charcoal-500 hover:text-charcoal-800 hover:bg-sage-100 transition-colors"
+          aria-label="Close"
+        >
+          <CloseIcon className="w-5 h-5" />
+        </button>
+
+        <div className="flex items-start gap-4 mb-4">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-amber-500/10 text-amber-600">
+            <AlertTriangle className="h-6 w-6" aria-hidden="true" />
+          </div>
+          <div className="flex-1 min-w-0 pr-6">
+            <h2 id="offline-dialog-title" className="text-xl font-noto font-medium text-charcoal-800 mb-2">
+              antiresume is coming back soon
+            </h2>
+            <p className="text-sm text-charcoal-600 leading-relaxed">
+              The project is temporarily offline while the database is down. Follow antiresume on X or Instagram for an alert when it&apos;s live again.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col sm:flex-row gap-3 mt-2">
+          <a
+            href="https://x.com/antiresume"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex-1 inline-flex items-center justify-center gap-2 bg-charcoal-700 hover:bg-charcoal-800 text-matcha-cream font-zen px-4 py-2.5 rounded-xl transition-all duration-200"
+          >
+            <ExternalLink className="w-4 h-4" />
+            Follow on X
+          </a>
+          <a
+            href="https://instagram.com/antiresume"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex-1 inline-flex items-center justify-center gap-2 bg-matcha-cream hover:bg-sage-100 text-charcoal-800 font-zen px-4 py-2.5 rounded-xl border-2 border-sage-300 hover:border-sage-400 transition-all duration-200"
+          >
+            <ExternalLink className="w-4 h-4" />
+            Follow on Instagram
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/OfflineDialog.tsx
+++ b/components/OfflineDialog.tsx
@@ -1,12 +1,30 @@
 'use client'
 
-import { AlertTriangle, ExternalLink, X as CloseIcon } from 'lucide-react'
+import { X as CloseIcon } from 'lucide-react'
 
 export const PROJECT_OFFLINE = true
 
 interface OfflineDialogProps {
   open: boolean
   onClose: () => void
+}
+
+function XLogo({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className={className} fill="currentColor">
+      <path d="M18.244 2H21.5l-7.51 8.582L23 22h-6.852l-5.36-7.024L4.6 22H1.34l8.04-9.187L1 2h7.02l4.84 6.4L18.244 2Zm-1.2 18h1.84L7.04 4H5.087l11.957 16Z" />
+    </svg>
+  )
+}
+
+function InstagramLogo({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className={className} fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="3" width="18" height="18" rx="5" />
+      <circle cx="12" cy="12" r="4" />
+      <circle cx="17.5" cy="6.5" r="0.9" fill="currentColor" stroke="none" />
+    </svg>
+  )
 }
 
 export default function OfflineDialog({ open, onClose }: OfflineDialogProps) {
@@ -21,50 +39,43 @@ export default function OfflineDialog({ open, onClose }: OfflineDialogProps) {
       aria-labelledby="offline-dialog-title"
     >
       <div
-        className="relative w-full max-w-md bg-matcha-cream rounded-2xl shadow-xl border-2 border-sage-300 p-6"
+        className="relative w-full max-w-xs bg-matcha-cream rounded-2xl shadow-xl border-2 border-sage-300 p-5 text-center"
         onClick={(event) => event.stopPropagation()}
       >
         <button
           type="button"
           onClick={onClose}
-          className="absolute top-3 right-3 p-1 rounded-md text-charcoal-500 hover:text-charcoal-800 hover:bg-sage-100 transition-colors"
+          className="absolute top-2 right-2 p-1 rounded-md text-charcoal-500 hover:text-charcoal-800 hover:bg-sage-100 transition-colors"
           aria-label="Close"
         >
-          <CloseIcon className="w-5 h-5" />
+          <CloseIcon className="w-4 h-4" />
         </button>
 
-        <div className="flex items-start gap-4 mb-4">
-          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-amber-500/10 text-amber-600">
-            <AlertTriangle className="h-6 w-6" aria-hidden="true" />
-          </div>
-          <div className="flex-1 min-w-0 pr-6">
-            <h2 id="offline-dialog-title" className="text-xl font-noto font-medium text-charcoal-800 mb-2">
-              antiresume is coming back soon
-            </h2>
-            <p className="text-sm text-charcoal-600 leading-relaxed">
-              The project is temporarily offline while the database is down. Follow antiresume on X or Instagram for an alert when it&apos;s live again.
-            </p>
-          </div>
-        </div>
+        <h2 id="offline-dialog-title" className="text-base font-noto font-medium text-charcoal-800 mb-1">
+          coming back soon
+        </h2>
+        <p className="text-xs text-charcoal-600 leading-relaxed mb-4">
+          follow for an alert when antiresume is live again
+        </p>
 
-        <div className="flex flex-col sm:flex-row gap-3 mt-2">
+        <div className="flex items-center justify-center gap-3">
           <a
             href="https://x.com/antiresume"
             target="_blank"
             rel="noopener noreferrer"
-            className="flex-1 inline-flex items-center justify-center gap-2 bg-charcoal-700 hover:bg-charcoal-800 text-matcha-cream font-zen px-4 py-2.5 rounded-xl transition-all duration-200"
+            aria-label="Follow antiresume on X"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-charcoal-700 hover:bg-charcoal-800 text-matcha-cream transition-all duration-200"
           >
-            <ExternalLink className="w-4 h-4" />
-            Follow on X
+            <XLogo className="h-4 w-4" />
           </a>
           <a
             href="https://instagram.com/antiresume"
             target="_blank"
             rel="noopener noreferrer"
-            className="flex-1 inline-flex items-center justify-center gap-2 bg-matcha-cream hover:bg-sage-100 text-charcoal-800 font-zen px-4 py-2.5 rounded-xl border-2 border-sage-300 hover:border-sage-400 transition-all duration-200"
+            aria-label="Follow antiresume on Instagram"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-matcha-cream hover:bg-sage-100 text-charcoal-800 border-2 border-sage-300 hover:border-sage-400 transition-all duration-200"
           >
-            <ExternalLink className="w-4 h-4" />
-            Follow on Instagram
+            <InstagramLogo className="h-4 w-4" />
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Database/project is currently offline. Intercept every entry point with a coming-soon dialog instead of letting users hit Clerk or navigate to profile routes:
  - Header **Sign In** and **Sign Up** buttons
  - Hero **Show your antiresume** CTA on the landing page
  - Example profile chips (`/jarrensj`)
- Dialog says antiresume is coming back soon and has two follow buttons: X (x.com/antiresume) and Instagram (instagram.com/antiresume).
- Gated behind a single `PROJECT_OFFLINE` constant in `components/OfflineDialog.tsx` — one-line flip to restore normal behavior when the database is back.
- Built with plain elements (no shadcn primitives) so it can ship off `main` independently of the in-flight shadcn migration in #65.

## Test plan

- [ ] Visit `/` signed-out — header Sign In / Sign Up open the offline dialog (not the Clerk modal).
- [ ] Click "Show your antiresume" — dialog opens with X + Instagram follow buttons; clicking the backdrop or X closes it.
- [ ] Click any `/jarrensj` example chip — dialog opens (no navigation to the profile route).
- [ ] Flip `PROJECT_OFFLINE` to `false` locally and confirm header buttons return to Clerk's auth modal and example links navigate normally.